### PR TITLE
更新taboolib;kotlin版本调整为1.5.31

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,8 +6,8 @@ plugins {
     `maven-publish`
     signing
     id("io.izzel.taboolib") version "1.56"
-    id("org.jetbrains.kotlin.jvm") version "1.7.20"
-    id("org.jetbrains.dokka") version "1.7.20"
+    id("org.jetbrains.kotlin.jvm") version "1.5.31"
+    id("org.jetbrains.dokka") version "1.5.31"
     id("com.github.johnrengelman.shadow") version "7.0.0"
     id("io.codearte.nexus-staging") version "0.30.0"
 }
@@ -74,7 +74,8 @@ taboolib {
         "module-nms-util",
         "module-lang",
         "module-porticus",
-        "expansion-alkaid-redis"
+        "expansion-alkaid-redis",
+        "expansion-javascript"
     )
     install(
         "platform-bukkit"
@@ -82,7 +83,7 @@ taboolib {
 
 
     classifier = null
-    version = "6.0.12-14"
+    version = "6.0.12-35"
 
     relocate("org.openjdk.nashorn", "com.skillw.nashorn")
     relocate("jdk.nashorn", "com.skillw.nashorn.legacy")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,8 +74,7 @@ taboolib {
         "module-nms-util",
         "module-lang",
         "module-porticus",
-        "expansion-alkaid-redis",
-        "expansion-javascript"
+        "expansion-alkaid-redis"
     )
     install(
         "platform-bukkit"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 #Sun Dec 18 16:16:45 CST 2022
-version=1.6.5
+version=1.6.6-beta
 group=com.skillw.pouvoir

--- a/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/Lang.kt
+++ b/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/Lang.kt
@@ -16,49 +16,49 @@ import com.skillw.asahi.api.quester
  * @date 2023/1/9 22:55 Copyright 2023 user. All rights reserved.
  */
 @AsahiPrefix(["null"], "lang")
-private fun `null`() = prefixParser {
+private fun `null`() = prefixParser<Any?> {
     result { null }
 }
 
 @AsahiPrefix(["null-str"], "lang")
-private fun nullStr() = prefixParser {
+private fun nullStr() = prefixParser<String> {
     result { "null" }
 }
 
 @AsahiPrefix(["pass"], "lang")
-private fun pass() = prefixParser {
+private fun pass() = prefixParser<String> {
     result { "" }
 }
 
 @AsahiPrefix(["true"], "lang")
-private fun `true`() = prefixParser {
+private fun `true`() = prefixParser<Boolean> {
     result { true }
 }
 
 @AsahiPrefix(["false"], "lang")
-private fun `false`() = prefixParser {
+private fun `false`() = prefixParser<Boolean> {
     result { false }
 }
 
 @AsahiPrefix(["return"], "lang")
-private fun `return`() = prefixParser {
+private fun `return`() = prefixParser<Any?> {
     val value = if (expect(";")) quester { Unit } else quest<Any?>()
     result { exit(); value.get() }
 }
 
 @AsahiPrefix(["exit", "stop"], "lang")
-private fun exit() = prefixParser {
+private fun exit() = prefixParser<Unit> {
     result { exit() }
 }
 
 @AsahiPrefix(["{"], "lang")
-private fun block() = prefixParser {
+private fun block() = prefixParser<Any?> {
     val script = splitTill("{", "}").compile(*namespaceNames())
     result { script.run() }
 }
 
 @AsahiPrefix(["using"], "lang")
-private fun using() = prefixParser {
+private fun using() = prefixParser<Any?> {
     val names = ArrayList<String>()
     if (peek() == "[") {
         while (!expect("]")) {
@@ -78,7 +78,7 @@ private fun using() = prefixParser {
 }
 
 @AsahiPrefix(["unusing"], "lang")
-private fun unusing() = prefixParser {
+private fun unusing() = prefixParser<String> {
     val name = next()
     removeSpaces(name)
     result { name }

--- a/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/Script.kt
+++ b/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/Script.kt
@@ -11,7 +11,7 @@ import com.skillw.pouvoir.util.toArgs
 private val funcRegex = Regex(".*?([a-zA-Z_$]+).*?\\((.*?)\\).*?")
 
 @AsahiPrefix(["fun", "def"], "lang")
-private fun `fun`() = prefixParser {
+private fun `fun`() = prefixParser<NativeFunction> {
     val result = funcRegex.find(splitBeforeString("{"))!!
     val name = result.groups[1]?.value!!
     val params = result.groups[2]?.value!!.toArgs().filter { it.isNotEmpty() && it.isNotBlank() }.toTypedArray()
@@ -22,7 +22,7 @@ private fun `fun`() = prefixParser {
 }
 
 @AsahiPrefix(["invoke", "call"], "lang")
-private fun invoke() = prefixParser {
+private fun invoke() = prefixParser<Any?> {
     val func = quest<String>()
     val paramsGetter = if (peek() == "[") quest<Array<Any>>() else quester { emptyArray() }
     result {
@@ -32,7 +32,7 @@ private fun invoke() = prefixParser {
 }
 
 @AsahiPrefix(["import"], "lang")
-private fun import() = prefixParser {
+private fun import() = prefixParser<Unit> {
     val paths = if (peek() == "[") quest() else quest<String>().quester { arrayOf(it) }
     result {
         import(*paths.get())

--- a/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/Variable.kt
+++ b/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/Variable.kt
@@ -13,7 +13,7 @@ import com.skillw.asahi.api.quest
  * @date 2023/1/13 19:09 Copyright 2023 user. All rights reserved.
  */
 @AsahiPrefix(["set"], "lang")
-private fun set() = prefixParser {
+private fun set() = prefixParser<Any?> {
     val key = next()
     when {
         expect("ifndef") -> {
@@ -51,19 +51,19 @@ private fun set() = prefixParser {
 }
 
 @AsahiPrefix(["has"], "lang")
-private fun has() = prefixParser {
+private fun has() = prefixParser<Boolean> {
     val key = quest<String>()
     result { get(key.get()) != null }
 }
 
 @AsahiPrefix(["get"], "lang")
-private fun get() = prefixParser {
+private fun get() = prefixParser<Any?> {
     val key = quest<String>()
     result { get(key.get()) }
 }
 
 @AsahiPrefix(["delete"], "lang")
-private fun delete() = prefixParser {
+private fun delete() = prefixParser<Any?> {
     val key = quest<String>()
     result { remove(key.get()) }
 }

--- a/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/linking/Java.kt
+++ b/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/linking/Java.kt
@@ -15,7 +15,7 @@ import taboolib.library.reflex.Reflex.Companion.invokeConstructor
  * @date 2023/1/18 18:19 Copyright 2023 user. All rights reserved.
  */
 @AsahiPrefix(["java"], "lang")
-private fun java() = prefixParser {
+private fun java() = prefixParser<Any?> {
     val isPackage = expect("in")
     expect("of")
     val path = questString()
@@ -31,7 +31,7 @@ private fun java() = prefixParser {
 }
 
 @AsahiPrefix(["new"], "lang")
-private fun new() = prefixParser {
+private fun new() = prefixParser<Any> {
     val clazz = next().let { quester { context()[it] as Class<*> } }
     val paramsGetter = if (peek() == "[" || peek() == "(") quest() else quester { emptyList<Any?>() }
     expect("[]", "()")

--- a/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/math/Calculate.kt
+++ b/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/math/Calculate.kt
@@ -14,7 +14,7 @@ import com.skillw.pouvoir.util.calculate.CalcOperator.Companion.toCalcOperator
  * @date 2023/1/14 0:31 Copyright 2023 user. All rights reserved.
  */
 @AsahiPrefix(["calculate", "calc"], "lang")
-private fun calculate() = prefixParser {
+private fun calculate() = prefixParser<Double> {
     val formulaGetter = quest<String>()
     result {
         val formula = formulaGetter.get().analysis(this, *namespaceNames())
@@ -23,7 +23,7 @@ private fun calculate() = prefixParser {
 }
 
 @AsahiPrefix(["math"], "lang")
-private fun math() = prefixParser {
+private fun math() = prefixParser<Double> {
     val numA = questDouble()
     val operator = questString().quester { it.first() }
     val numB = questDouble()

--- a/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/math/Math.kt
+++ b/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/math/Math.kt
@@ -13,42 +13,42 @@ import com.skillw.asahi.api.quest
 
 
 @AsahiPrefix(["sin"], "lang")
-private fun sin() = prefixParser {
+private fun sin() = prefixParser<Double>  {
     //弧度制
     val radians = quest<Double>()
     result { kotlin.math.sin(radians.get()) }
 }
 
 @AsahiPrefix(["cos"], "lang")
-private fun cos() = prefixParser {
+private fun cos() = prefixParser<Double> {
     //弧度制
     val radians = quest<Double>()
     result { kotlin.math.cos(radians.get()) }
 }
 
 @AsahiPrefix(["tan"], "lang")
-private fun tan() = prefixParser {
+private fun tan() = prefixParser<Double> {
     //弧度制
     val radians = quest<Double>()
     result { kotlin.math.tan(radians.get()) }
 }
 
 @AsahiPrefix(["asin"], "lang")
-private fun asin() = prefixParser {
+private fun asin() = prefixParser<Double> {
     val radians = quest<Double>()
     //返回弧度制
     result { kotlin.math.asin(radians.get()) }
 }
 
 @AsahiPrefix(["acos"], "lang")
-private fun acos() = prefixParser {
+private fun acos() = prefixParser<Double> {
     val radians = quest<Double>()
     //返回弧度制
     result { kotlin.math.cos(radians.get()) }
 }
 
 @AsahiPrefix(["atan"], "lang")
-private fun atan() = prefixParser {
+private fun atan() = prefixParser<Double> {
     val radians = quest<Double>()
     //返回弧度制
     result { kotlin.math.atan(radians.get()) }
@@ -60,26 +60,26 @@ private fun atan() = prefixParser {
  * @return PrefixCreator<Double>
  */
 @AsahiPrefix(["log"], "lang")
-private fun log() = prefixParser {
+private fun log() = prefixParser<Double> {
     val x = quest<Double>()
     val base = quest<Double>()
     result { kotlin.math.log(x.get(), base.get()) }
 }
 
 @AsahiPrefix(["log10", "lg"], "lang")
-private fun log10() = prefixParser {
+private fun log10() = prefixParser<Double> {
     val x = quest<Double>()
     result { kotlin.math.log10(x.get()) }
 }
 
 @AsahiPrefix(["ln"], "lang")
-private fun ln() = prefixParser {
+private fun ln() = prefixParser<Double> {
     val x = quest<Double>()
     result { kotlin.math.ln(x.get()) }
 }
 
 @AsahiPrefix(["log2"], "lang")
-private fun log2() = prefixParser {
+private fun log2() = prefixParser<Double> {
     val x = quest<Double>()
     result { kotlin.math.log2(x.get()) }
 }

--- a/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/math/Number.kt
+++ b/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/math/Number.kt
@@ -16,32 +16,32 @@ import kotlin.math.absoluteValue
 
 
 @AsahiPrefix(["abs"], "lang")
-private fun abs() = prefixParser {
+private fun abs() = prefixParser<Double> {
     val number = quest<Double>()
     result { number.get().absoluteValue }
 }
 
 @AsahiPrefix(["ceil"], "lang")
-private fun ceil() = prefixParser {
+private fun ceil() = prefixParser<Double> {
     val number = quest<Double>()
     result { kotlin.math.ceil(number.get()) }
 }
 
 @AsahiPrefix(["floor"], "lang")
-private fun floor() = prefixParser {
+private fun floor() = prefixParser<Double> {
     val number = quest<Double>()
     result { kotlin.math.floor(number.get()) }
 }
 
 @AsahiPrefix(["format"], "lang")
-private fun format() = prefixParser {
+private fun format() = prefixParser<String> {
     val number = quest<Double>()
     val format = quest<String>()
     result { number.get().format(format.get()) }
 }
 
 @AsahiPrefix(["max"], "lang")
-private fun max() = prefixParser {
+private fun max() = prefixParser<Double> {
     val value = if (peek() == "[")
         quest<List<Any?>>()
     else {
@@ -69,7 +69,7 @@ private fun max() = prefixParser {
 }
 
 @AsahiPrefix(["min"], "lang")
-private fun min() = prefixParser {
+private fun min() = prefixParser<Double> {
     val value = if (peek() == "[")
         quest<List<Any?>>()
     else {
@@ -97,13 +97,13 @@ private fun min() = prefixParser {
 }
 
 @AsahiPrefix(["round"], "lang")
-private fun round() = prefixParser {
+private fun round() = prefixParser<Int> {
     val x = quest<Double>()
     result { kotlin.math.round(x.get()).toInt() }
 }
 
 @AsahiPrefix(["range"], "lang")
-private fun range() = prefixParser {
+private fun range() = prefixParser<ClosedFloatingPointRange<Double>> {
     val from = quest<Double>()
     expect("to", "~", "..")
     val to = quest<Double>()
@@ -115,7 +115,7 @@ private fun range() = prefixParser {
 }
 
 @AsahiPrefix(["number"], "lang")
-private fun number() = prefixParser {
+private fun number() = prefixParser<Double> {
     val number = quest<Double>()
     result { number.get() }
 }

--- a/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/math/Random.kt
+++ b/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/math/Random.kt
@@ -14,7 +14,7 @@ import taboolib.common5.RandomList
  */
 
 @AsahiPrefix(["random"], "lang")
-private fun random() = prefixParser {
+private fun random() = prefixParser<String> {
     val x = quest<Double>()
     expect("to")
     val y = quest<Double>()
@@ -22,7 +22,7 @@ private fun random() = prefixParser {
 }
 
 @AsahiPrefix(["randomInt"], "lang")
-private fun randomInt() = prefixParser {
+private fun randomInt() = prefixParser<Int> {
     val x = quest<Int>()
     expect("to")
     val y = quest<Int>()
@@ -30,13 +30,13 @@ private fun randomInt() = prefixParser {
 }
 
 @AsahiPrefix(["randomObj"], "lang")
-private fun randomObj() = prefixParser {
+private fun randomObj() = prefixParser<Any> {
     val list = quest<List<Any>>()
     result { list.get().random() }
 }
 
 @AsahiPrefix(["weight"], "lang")
-private fun weight() = prefixParser {
+private fun weight() = prefixParser<Any> {
     expect("[")
     val list = ArrayList<Pair<Quester<Int>, Quester<Any>>>()
     do {

--- a/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/structure/Condition.kt
+++ b/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/structure/Condition.kt
@@ -14,7 +14,7 @@ import com.skillw.asahi.api.quester
  */
 
 @AsahiPrefix(["condition"], "lang")
-private fun condition() = prefixParser {
+private fun condition() = prefixParser<Boolean> {
     val condition = questCondition(";")
     result {
         condition.get()
@@ -23,7 +23,7 @@ private fun condition() = prefixParser {
 
 //单路
 @AsahiPrefix(["if"], "lang")
-private fun `if`() = prefixParser {
+private fun `if`() = prefixParser<Any?> {
     val condition = questCondition("then")
     expect("then")
     val ifTrue = quest<Any?>()
@@ -36,7 +36,7 @@ private fun `if`() = prefixParser {
 
 //多路
 @AsahiPrefix(["when", "switch"], "lang")
-private fun `when`() = prefixParser {
+private fun `when`() = prefixParser<Any?> {
     val value = if (expect("of")) quest<Any?>() else null
     val pairs = ArrayList<Pair<Quester<Boolean>, Quester<Any?>>>()
     expect("{")

--- a/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/structure/Loop.kt
+++ b/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/structure/Loop.kt
@@ -18,7 +18,7 @@ import java.util.*
  * @date 2023/1/14 0:25 Copyright 2023 user. All rights reserved.
  */
 @AsahiPrefix(["while"], "lang")
-private fun `while`() = prefixParser {
+private fun `while`() = prefixParser<Unit> {
     val condition = questCondition("label", "then")
     runLoop { loopOnce ->
         while (condition.get()) {
@@ -31,7 +31,7 @@ private fun `while`() = prefixParser {
 }
 
 @AsahiPrefix(["repeat"], "lang")
-private fun repeat() = prefixParser {
+private fun repeat() = prefixParser<Unit> {
     val time = quest<Int>()
     val indexName = if (expect("with")) quest() else quester { "index" }
     runLoop { loopOnce ->
@@ -47,7 +47,7 @@ private fun repeat() = prefixParser {
 }
 
 @AsahiPrefix(["foreach", "for"], "lang")
-private fun foreach() = prefixParser {
+private fun foreach() = prefixParser<Unit> {
     val paramName = next()
     expect("in")
     val getter = quest<Any>()
@@ -114,7 +114,7 @@ private fun PrefixParser<*>.runLoop(
 }
 
 @AsahiPrefix(["break"], "lang")
-private fun `break`() = prefixParser {
+private fun `break`() = prefixParser<Unit> {
     val labelGetter = if (expect("the")) quest() else quester { (context() as LoopContext).label }
     result {
         if (this !is LoopContext) return@result
@@ -129,7 +129,7 @@ private fun `break`() = prefixParser {
 }
 
 @AsahiPrefix(["continue"], "lang")
-private fun `continue`() = prefixParser {
+private fun `continue`() = prefixParser<Unit> {
     val labelGetter = if (expect("the")) quest() else quester { (context() as LoopContext).label }
     result {
         if (this !is LoopContext) return@result

--- a/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/util/Logger.kt
+++ b/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/util/Logger.kt
@@ -12,7 +12,7 @@ import taboolib.module.chat.colored
  * @date 2023/1/14 0:22 Copyright 2023 user. All rights reserved.
  */
 @AsahiPrefix(["print", "info"], "lang")
-fun info() = prefixParser {
+fun info() = prefixParser<Any> {
     //开始此函数的"编译"(parse)
     val content = quest<Any>()  //寻求一个任意类型对象
     // result里是执行函数时，要干的事情
@@ -25,7 +25,7 @@ fun info() = prefixParser {
 }
 
 @AsahiPrefix(["warning", "warn"], "lang")
-fun warning() = prefixParser {
+fun warning() = prefixParser<Any> {
     val content = quest<Any>()
     result {
         content.get().also {
@@ -35,7 +35,7 @@ fun warning() = prefixParser {
 }
 
 @AsahiPrefix(["error"], "lang")
-fun error() = prefixParser {
+fun error() = prefixParser<Any> {
     val content = quest<Any>()
     result {
         content.get().also {

--- a/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/util/Logic.kt
+++ b/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/util/Logic.kt
@@ -12,13 +12,13 @@ import com.skillw.asahi.util.cast
  * @date 2023/1/14 0:15 Copyright 2023 user. All rights reserved.
  */
 @AsahiPrefix(["not"], "lang")
-private fun not() = prefixParser {
+private fun not() = prefixParser<Boolean> {
     val bool = quest<Boolean>()
     result { !bool.get() }
 }
 
 @AsahiPrefix(["all"], "lang")
-private fun all() = prefixParser {
+private fun all() = prefixParser<Boolean> {
     val array = quest<Array<Any?>>()
     result {
         array.get().all { it.cast() }
@@ -27,7 +27,7 @@ private fun all() = prefixParser {
 }
 
 @AsahiPrefix(["any"], "lang")
-private fun any() = prefixParser {
+private fun any() = prefixParser<Boolean> {
     val array = quest<Array<Any?>>()
     result {
         array.get().any { it.cast() }
@@ -35,7 +35,7 @@ private fun any() = prefixParser {
 }
 
 @AsahiPrefix(["check", "?"], "lang")
-private fun check() = prefixParser {
+private fun check() = prefixParser<Boolean> {
     val a = quest<Any>()
     val symbol = next()
     val b = quest<Any>()

--- a/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/util/PrefixDebug.kt
+++ b/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/util/PrefixDebug.kt
@@ -20,7 +20,7 @@ internal object PrefixDebug {
     }
 
     @AsahiPrefix(["debug"], "lang")
-    private fun debugFunc() = prefixParser {
+    private fun debugFunc() = prefixParser<Any?> {
         when (next()) {
             "context" -> result {
                 debug(context())

--- a/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/util/PrefixGson.kt
+++ b/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/util/PrefixGson.kt
@@ -8,7 +8,7 @@ import com.skillw.pouvoir.util.findClass
 
 internal object PrefixGson {
     @AsahiPrefix(["gson"], "lang")
-    private fun gson() = prefixParser {
+    private fun gson() = prefixParser<Any?> {
         when (val type = next()) {
             "encode" -> {
                 val any = questAny()

--- a/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/util/PrefixRegex.kt
+++ b/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/util/PrefixRegex.kt
@@ -8,14 +8,15 @@ import com.skillw.asahi.api.script.linking.NativeFunction
 
 internal object PrefixRegex {
     @AsahiPrefix(["regexOf"], "regex")
-    private fun regexOf() = prefixParser {
+    private fun regexOf() = prefixParser<Regex> {
         val regex = quest<String>()
         val options = if (expect("with")) quest() else quester { emptySet<RegexOption>() }
         result { regex.get().toRegex(options.get()) }
     }
 
+    @OptIn(ExperimentalStdlibApi::class)
     @AsahiPrefix(["regex"], "regex")
-    private fun regex() = prefixParser {
+    private fun regex() = prefixParser<Any?> {
         val regex = if (expect("of")) quest<String>().quester { it.toRegex() } else quester { selector() }
         when (val type = next()) {
             "find" -> {

--- a/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/util/String.kt
+++ b/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/util/String.kt
@@ -12,7 +12,7 @@ import com.skillw.asahi.api.quest
  * @date 2023/1/17 15:37 Copyright 2023 user. All rights reserved.
  */
 @AsahiPrefix(["analysis", "inline"], "lang")
-private fun inline() = prefixParser {
+private fun inline() = prefixParser<Any> {
     val text = if (expect("all")) questList() else quest<String>()
     result {
         text.get().let { obj ->

--- a/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/util/Util.kt
+++ b/src/main/kotlin/com/skillw/asahi/internal/namespacing/prefix/lang/util/Util.kt
@@ -18,25 +18,25 @@ import java.util.*
  * @date 2023/1/14 0:45 Copyright 2023 user. All rights reserved.
  */
 @AsahiPrefix(["arrayOf"], "lang")
-private fun arrayOf() = prefixParser {
+private fun arrayOf() = prefixParser<Any?> {
     val array = quest<Array<Any?>>()
     result { array.get() }
 }
 
 @AsahiPrefix(["listOf"], "lang")
-private fun listOf() = prefixParser {
+private fun listOf() = prefixParser<Any?> {
     val list = quest<List<Any?>>()
     result { list.get() }
 }
 
 @AsahiPrefix(["setOf"], "lang")
-private fun setOf() = prefixParser {
+private fun setOf() = prefixParser<Any?> {
     val set = quest<Set<Any?>>()
     result { set.get() }
 }
 
 @AsahiPrefix(["mapOf"], "lang")
-private fun mapOf() = prefixParser {
+private fun mapOf() = prefixParser<Any?> {
     if (expect("with")) {
         val template = quest<MapTemplate>()
         val list = quest<List<Any>>()
@@ -48,7 +48,7 @@ private fun mapOf() = prefixParser {
 }
 
 @AsahiPrefix(["mapListOf"], "lang")
-private fun mapListOf() = prefixParser {
+private fun mapListOf() = prefixParser<MutableList<MutableMap<String,Any>>> {
     expect("with")
     val templateGetter = quest<MapTemplate>()
     val list = quest<List<Any>>()
@@ -60,13 +60,13 @@ private fun mapListOf() = prefixParser {
 }
 
 @AsahiPrefix(["pair"], "lang")
-private fun pair() = prefixParser {
+private fun pair() = prefixParser<Pair<Any,Any>> {
     val pair = quest<Pair<Any, Any>>()
     result { pair.get() }
 }
 
 @AsahiPrefix(["mapTemplate"], "lang")
-private fun mapTemplate() = prefixParser {
+private fun mapTemplate() = prefixParser<MapTemplate> {
     val list = quest<List<Any>>()
     result { MapTemplate(list.get().map { it.toString() }) }
 }
@@ -78,7 +78,7 @@ private fun mapTemplate() = prefixParser {
  * @date 2023/1/14 0:42 Copyright 2023 user. All rights reserved.
  */
 @AsahiPrefix(["join"], "lang")
-private fun join() = prefixParser {
+private fun join() = prefixParser<String> {
     val list = quest<List<Any>>()
     val by = if (expect("by")) quest() else quester { "" }
     result {
@@ -87,7 +87,7 @@ private fun join() = prefixParser {
 }
 
 @AsahiPrefix(["replace"], "lang")
-private fun replace() = prefixParser {
+private fun replace() = prefixParser<String> {
     val str = quest<String>()
     expect("with")
     val replacement = quest<Map<String, Any>>()
@@ -101,7 +101,7 @@ private fun replace() = prefixParser {
 }
 
 @AsahiPrefix(["type"], "lang")
-fun type() = prefixParser {
+fun type() = prefixParser<Any?> {
     val type = quest<String>()
     val getter = quest<Any?>()
     result {
@@ -122,7 +122,7 @@ fun type() = prefixParser {
 }
 
 @AsahiPrefix(["select", "with"], "lang")
-private fun with() = prefixParser {
+private fun with() = prefixParser<Any> {
     val any = quest<Any>()
     val exec = parseScript()
     result {
@@ -146,7 +146,7 @@ private fun with() = prefixParser {
 }
 
 @AsahiPrefix(["date"], "lang")
-private fun date() = prefixParser {
+private fun date() = prefixParser<String> {
     val typeGetter = if (expect("in")) questString() else quester { null }
     result {
         val date = Date()
@@ -165,7 +165,7 @@ private fun date() = prefixParser {
 
 
 @AsahiPrefix(["time"], "lang")
-private fun time() = prefixParser {
+private fun time() = prefixParser<String> {
     val formatGetter = if (expect("as")) questString() else quester { "yyyy-MM-dd HH:mm:ss" }
     result {
         SimpleDateFormat(formatGetter.get()).format(Date())
@@ -173,7 +173,7 @@ private fun time() = prefixParser {
 }
 
 @AsahiPrefix(["color"])
-private fun color() = prefixParser {
+private fun color() = prefixParser<Color> {
     expect("[")
     val r = quest<Int>()
     val g = quest<Int>()
@@ -184,7 +184,7 @@ private fun color() = prefixParser {
 
 
 @AsahiPrefix(["currentTick"], "lang")
-private fun currentTick() = prefixParser {
+private fun currentTick() = prefixParser<Long> {
     result {
         Clock.currentTick
     }

--- a/src/main/kotlin/com/skillw/pouvoir/Pouvoir.kt
+++ b/src/main/kotlin/com/skillw/pouvoir/Pouvoir.kt
@@ -38,7 +38,7 @@ object Pouvoir : SubPouvoir, Plugin() {
     @Config(migrate = true, autoReload = true)
     lateinit var config: ConfigFile
 
-    @Config("script.yml", true, autoReload = true)
+    @Config("script.yml", migrate = true, autoReload = true)
     lateinit var script: ConfigFile
 
     /** Managers */

--- a/src/main/kotlin/com/skillw/pouvoir/api/feature/database/sql/IPouTable.kt
+++ b/src/main/kotlin/com/skillw/pouvoir/api/feature/database/sql/IPouTable.kt
@@ -44,7 +44,7 @@ interface IPouTable<T : Host<E>, E : ColumnBuilder> {
      * @return 结果
      * @receiver
      */
-    fun select(func: ActionSelect.() -> Unit): QueryTask
+    fun select(func: ActionSelect.() -> Unit): ResultProcessorList
 
     /**
      * 寻找数据
@@ -90,7 +90,7 @@ interface IPouTable<T : Host<E>, E : ColumnBuilder> {
      * @return 结果
      * @receiver
      */
-    fun workspace(func: Query.() -> Unit): QueryTask
+    fun workspace(func: ExecutableSource.() -> Unit): ResultProcessorList
 
     /** 关闭数据源 */
     fun close()

--- a/src/main/kotlin/com/skillw/pouvoir/internal/core/asahi/prefix/bukkit/Basic.kt
+++ b/src/main/kotlin/com/skillw/pouvoir/internal/core/asahi/prefix/bukkit/Basic.kt
@@ -24,7 +24,7 @@ import taboolib.module.chat.uncolored
  */
 
 @AsahiPrefix(["command"])
-private fun command() = prefixParser {
+private fun command() = prefixParser<Unit> {
     val contentGetter = if (peek() == "[") questList() else questString()
     val whoGetter = if (expect("as")) {
         if (expect("op")) {
@@ -51,7 +51,7 @@ private fun command() = prefixParser {
 }
 
 @AsahiPrefix
-private fun colored() = prefixParser {
+private fun colored() = prefixParser<String> {
     val message = quest<String>()
     result {
         message.get().colored()
@@ -59,7 +59,7 @@ private fun colored() = prefixParser {
 }
 
 @AsahiPrefix
-private fun decolored() = prefixParser {
+private fun decolored() = prefixParser<String> {
     val message = quest<String>()
     result {
         message.get().decolored()
@@ -67,7 +67,7 @@ private fun decolored() = prefixParser {
 }
 
 @AsahiPrefix
-private fun uncolored() = prefixParser {
+private fun uncolored() = prefixParser<String> {
     val message = quest<String>()
     result {
         message.get().uncolored()
@@ -75,7 +75,7 @@ private fun uncolored() = prefixParser {
 }
 
 @AsahiPrefix(["papi", "placeholder"])
-private fun papi() = prefixParser {
+private fun papi() = prefixParser<String> {
     val entity = if (expect("of")) quest<LivingEntity>() else quester { selector() }
     val str = quest<String>()
     result {

--- a/src/main/kotlin/com/skillw/pouvoir/internal/core/asahi/prefix/bukkit/Condition.kt
+++ b/src/main/kotlin/com/skillw/pouvoir/internal/core/asahi/prefix/bukkit/Condition.kt
@@ -15,7 +15,7 @@ import org.bukkit.entity.LivingEntity
  */
 
 @AsahiPrefix(["cond"])
-private fun cond() = prefixParser {
+private fun cond() = prefixParser<Boolean> {
     val entity = if (expect("of")) quest<LivingEntity>() else quester { selector() }
     when (val type = next()) {
         in arrayOf("test") -> {

--- a/src/main/kotlin/com/skillw/pouvoir/internal/core/asahi/prefix/bukkit/LivingEntity.kt
+++ b/src/main/kotlin/com/skillw/pouvoir/internal/core/asahi/prefix/bukkit/LivingEntity.kt
@@ -31,7 +31,7 @@ import java.util.concurrent.ConcurrentHashMap
  * @date 2023/1/14 0:32 Copyright 2023 user. All rights reserved.
  */
 @AsahiPrefix(["damage"])
-private fun damage() = prefixParser {
+private fun damage() = prefixParser<Unit> {
     val defenderGetter = quest<LivingEntity>()
     val amount = quest<Double>()
     val attackerGetter = if (expect("by")) quest<LivingEntity>() else quester { null }
@@ -45,7 +45,7 @@ private fun damage() = prefixParser {
 }
 
 @AsahiPrefix(["potion"])
-private fun potion() = prefixParser {
+private fun potion() = prefixParser<Any> {
     when (val operType = next()) {
         "add" -> {
             //药水类型
@@ -135,7 +135,7 @@ private fun potion() = prefixParser {
 private val cache = ConcurrentHashMap<String, AttributeModifier>()
 
 @AsahiPrefix(["attribute"])
-private fun attribute() = prefixParser {
+private fun attribute() = prefixParser<Any?> {
     val attributeGetter = quest<BukkitAttribute>()
     val instanceGetter = (if (expect("of")) quest<LivingEntity>() else quester { selector() }).quester {
         NMS.INSTANCE.getAttribute(

--- a/src/main/kotlin/com/skillw/pouvoir/internal/core/asahi/prefix/bukkit/Player.kt
+++ b/src/main/kotlin/com/skillw/pouvoir/internal/core/asahi/prefix/bukkit/Player.kt
@@ -42,7 +42,7 @@ private fun sound() = prefixParser<Sound> {
 }
 
 @AsahiPrefix(["tell", "send", "message"])
-private fun tell() = prefixParser {
+private fun tell() = prefixParser<Unit> {
     val targets = if (expect("all")) quester { Bukkit.getOnlinePlayers() } else questAny()
     val contentGetter = if (peek() == "[") questList() else questString()
     result {
@@ -66,7 +66,7 @@ private fun tell() = prefixParser {
 }
 
 @AsahiPrefix(["actionbar"])
-private fun actionbar() = prefixParser {
+private fun actionbar() = prefixParser<Unit> {
     val targets = if (expect("all")) quester { Bukkit.getOnlinePlayers() } else questAny()
     val period = if (expect("every")) questTick() else quester { 20L }
     val contentGetter = if (peek() == "[") questList() else questString()
@@ -94,7 +94,7 @@ private fun actionbar() = prefixParser {
 }
 
 @AsahiPrefix(["title"])
-private fun title() = prefixParser {
+private fun title() = prefixParser<Unit> {
     val targets = if (expect("all")) quester { Bukkit.getOnlinePlayers() } else questAny()
     //主标题
     val title = quest<String?>()
@@ -134,7 +134,7 @@ private fun title() = prefixParser {
 private val bossBars = ConcurrentHashMap<String, BossBar>()
 
 @AsahiPrefix(["bossbar"])
-private fun bossbar() = prefixParser {
+private fun bossbar() = prefixParser<BossBar?> {
     if (expect("release")) {
         val barKeyGetter = questString()
         return@prefixParser result {
@@ -159,7 +159,7 @@ private fun bossbar() = prefixParser {
 
 
 @AsahiPrefix(["permission", "perm"])
-private fun permission() = prefixParser {
+private fun permission() = prefixParser<Any?> {
     val playerGetter = if (expect("of")) quest<Player>() else quester { selector() }
     when (next()) {
         "add" -> {
@@ -236,7 +236,7 @@ private val economy by unsafeLazy {
 }
 
 @AsahiPrefix(["money", "economy", "eco"])
-private fun money() = prefixParser {
+private fun money() = prefixParser<Any> {
     val player = if (expect("of")) quest<Player>() else quester { selector() }
     when (val type = next()) {
         in arrayOf("add", "deposit") -> {

--- a/src/main/kotlin/com/skillw/pouvoir/internal/core/asahi/prefix/bukkit/Selector.kt
+++ b/src/main/kotlin/com/skillw/pouvoir/internal/core/asahi/prefix/bukkit/Selector.kt
@@ -35,7 +35,7 @@ fun AsahiLexer.questTarget(): Quester<Target> {
 
 
 @AsahiPrefix(["targets"])
-private fun targets() = prefixParser {
+private fun targets() = prefixParser<Any?> {
     val result = quester { selectorSafely<SelectResult>() ?: select(SelectResult()) }
     when {
         expect("add") -> {
@@ -135,7 +135,7 @@ private fun AsahiLexer.params(): Any {
 }
 
 @AsahiPrefix(["selector"])
-private fun selector() = prefixParser {
+private fun selector() = prefixParser<SelectResult> {
     val casterQuester = questTarget()
     expect("[")
     var token = next()
@@ -169,7 +169,7 @@ private fun selector() = prefixParser {
 }
 
 @AsahiPrefix(["filter"])
-private fun filter() = prefixParser {
+private fun filter() = prefixParser<SelectResult> {
     val casterQuester = questTarget()
     expect("[")
     var token = next()
@@ -221,7 +221,7 @@ private enum class OperateType {
 }
 
 @AsahiPrefix(["flag"])
-private fun flag() = prefixParser {
+private fun flag() = prefixParser<Any> {
     val operateType = quest<OperateType>()
     val key = quest<String>()
     val time = if (expect("time", "duration")) quest() else quester { Time.noTime }

--- a/src/main/kotlin/com/skillw/pouvoir/internal/core/asahi/prefix/bukkit/Task.kt
+++ b/src/main/kotlin/com/skillw/pouvoir/internal/core/asahi/prefix/bukkit/Task.kt
@@ -17,7 +17,7 @@ import java.util.concurrent.CompletableFuture
  * @date 2023/1/14 0:56 Copyright 2023 user. All rights reserved.
  */
 @AsahiPrefix(["async", "taskAsync"])
-private fun async() = prefixParser {
+private fun async() = prefixParser<Unit> {
     var delayGetter = quester { 0L }
     var periodGetter = quester { 0L }
     if (expect("in")) {
@@ -44,7 +44,7 @@ private fun async() = prefixParser {
 }
 
 @AsahiPrefix(["sync", "taskSync", "task"])
-private fun sync() = prefixParser {
+private fun sync() = prefixParser<Unit> {
     var delayGetter = quester { 0L }
     var periodGetter = quester { 0L }
     if (expect("in")) {
@@ -71,7 +71,7 @@ private fun sync() = prefixParser {
 }
 
 @AsahiPrefix(["inSync"])
-private fun inSync() = prefixParser {
+private fun inSync() = prefixParser<Any?> {
     val content = parseScript()
     result {
         taboolib.common.util.sync {
@@ -106,7 +106,7 @@ private fun await() = prefixParser<Any?> {
 
 
 @AsahiPrefix(["wait", "delay", "sleep"], "lang")
-private fun delay() = prefixParser {
+private fun delay() = prefixParser<Unit> {
     val tick = questTick()
     result {
         delay(tick.get())

--- a/src/main/kotlin/com/skillw/pouvoir/internal/core/asahi/prefix/bukkit/World.kt
+++ b/src/main/kotlin/com/skillw/pouvoir/internal/core/asahi/prefix/bukkit/World.kt
@@ -17,7 +17,7 @@ import org.bukkit.util.Vector
  */
 
 @AsahiPrefix(["world"])
-private fun world() = prefixParser {
+private fun world() = prefixParser<World> {
     val getter = quest<String>()
     result {
         val name = getter.get()
@@ -26,7 +26,7 @@ private fun world() = prefixParser {
 }
 
 @AsahiPrefix(["location"])
-private fun location() = prefixParser {
+private fun location() = prefixParser<Location> {
     expect("[")
     val world = quest<World>()
     val x = quest<Double>()
@@ -43,7 +43,7 @@ private fun location() = prefixParser {
 }
 
 @AsahiPrefix(["vector"])
-private fun vector() = prefixParser {
+private fun vector() = prefixParser<Vector> {
     expect("[")
     val x = quest<Double>()
     val y = quest<Double>()

--- a/src/main/kotlin/com/skillw/pouvoir/internal/core/asahi/prefix/bukkit/particle/Particle.kt
+++ b/src/main/kotlin/com/skillw/pouvoir/internal/core/asahi/prefix/bukkit/particle/Particle.kt
@@ -21,7 +21,7 @@ import taboolib.platform.util.toProxyLocation
  */
 
 @AsahiPrefix(["particle"])
-private fun particle() = prefixParser {
+private fun particle() = prefixParser<Unit> {
     //粒子类型
     val particle = quest<ProxyParticle>()
     expect("at")
@@ -53,6 +53,6 @@ private fun particle() = prefixParser {
 
 //FIXME 这里要写粒子库对接
 @AsahiPrefix(["effect"])
-private fun effect() = prefixParser {
+private fun effect() = prefixParser<Unit> {
     result { }
 }

--- a/src/main/kotlin/com/skillw/pouvoir/internal/core/asahi/prefix/bukkit/particle/ParticleData.kt
+++ b/src/main/kotlin/com/skillw/pouvoir/internal/core/asahi/prefix/bukkit/particle/ParticleData.kt
@@ -21,7 +21,7 @@ import java.awt.Color
  */
 
 @AsahiPrefix(["particleData"])
-fun particleData() = prefixParser {
+fun particleData() = prefixParser<ProxyParticle.Data> {
     val token = next()
     expect("[", "{")
     when (token) {
@@ -79,7 +79,7 @@ private fun PrefixParser<*>.questItemData(): Quester<ProxyParticle.ItemData> {
 }
 
 @AsahiPrefix
-fun destination() = prefixParser {
+fun destination() = prefixParser<ProxyParticle.VibrationData.Destination> {
     when (val token = next()) {
         "location" -> {
             val loc = quest<org.bukkit.Location>()

--- a/src/main/kotlin/com/skillw/pouvoir/internal/core/asahi/prefix/database/Database.kt
+++ b/src/main/kotlin/com/skillw/pouvoir/internal/core/asahi/prefix/database/Database.kt
@@ -12,7 +12,7 @@ import com.skillw.pouvoir.internal.feature.database.PouvoirContainer
 
 
 @AsahiPrefix(["container"], "lang")
-private fun container() = prefixParser {
+private fun container() = prefixParser<Any?> {
     when (val top = next()) {
         "pouvoir" -> result {
             PouvoirContainer.container
@@ -49,7 +49,7 @@ private fun container() = prefixParser {
 
 
 @AsahiPrefix(["userdata"], "lang")
-private fun userdata() = prefixParser {
+private fun userdata() = prefixParser<Any?> {
     val container = if (expect("of")) quest<UserBased>() else quester { selector() }
     val user = questString()
     when (val top = next()) {

--- a/src/main/kotlin/com/skillw/pouvoir/internal/core/asahi/prefix/database/MongoDB.kt
+++ b/src/main/kotlin/com/skillw/pouvoir/internal/core/asahi/prefix/database/MongoDB.kt
@@ -13,7 +13,7 @@ import com.skillw.pouvoir.internal.feature.database.mongodb.MongoContainer
  * @date 2023/1/19 15:06 Copyright 2023 user. All rights reserved.
  */
 @AsahiPrefix(["mongo"])
-private fun mongo() = prefixParser {
+private fun mongo() = prefixParser<Any> {
     val container =
         if (expect("of")) quest<MongoContainer>()
         else quester { selector() }

--- a/src/main/kotlin/com/skillw/pouvoir/internal/core/asahi/prefix/database/Redis.kt
+++ b/src/main/kotlin/com/skillw/pouvoir/internal/core/asahi/prefix/database/Redis.kt
@@ -13,7 +13,7 @@ import com.skillw.pouvoir.internal.feature.database.redis.RedisContainer
  * @date 2023/1/19 15:06 Copyright 2023 user. All rights reserved.
  */
 @AsahiPrefix(["redis"], "lang")
-private fun redis() = prefixParser {
+private fun redis() = prefixParser<Any?> {
     val connectionGetter =
         if (expect("of")) quest<RedisContainer>().quester { it.connection }
         else quester { selector<RedisContainer>().connection }

--- a/src/main/kotlin/com/skillw/pouvoir/internal/core/asahi/prefix/database/sql/Sql.kt
+++ b/src/main/kotlin/com/skillw/pouvoir/internal/core/asahi/prefix/database/sql/Sql.kt
@@ -16,7 +16,7 @@ import taboolib.module.database.QueryTask
  */
 
 @AsahiPrefix(["sql"], "sql")
-private fun sql() = prefixParser {
+private fun sql() = prefixParser<Any> {
     val containerGetter = if (expect("of")) quest<IPouTable<*, *>>() else quester { selector() }
     when (val top = next()) {
 
@@ -95,7 +95,7 @@ private fun sql() = prefixParser {
 }
 
 @AsahiPrefix(["query"], "sql")
-private fun query() = prefixParser {
+private fun query() = prefixParser<Any?> {
     val queryGetter = if (expect("of")) quest<QueryTask>() else quester { selector() }
     when (val top = next()) {
         "find" -> result { queryGetter.get().find() }

--- a/src/main/kotlin/com/skillw/pouvoir/internal/core/asahi/prefix/database/sql/Where.kt
+++ b/src/main/kotlin/com/skillw/pouvoir/internal/core/asahi/prefix/database/sql/Where.kt
@@ -45,7 +45,7 @@ private fun Any.formatColumn(): String {
 }
 
 @AsahiPrefix(["where"], "sql-where-action")
-private fun where() = prefixParser {
+private fun where() = prefixParser<WhereData> {
     val keyGetter = quest<String>()
     val symbolGetter = quest<String>()
     val valueGetter = quest<String>()
@@ -62,7 +62,7 @@ private fun where() = prefixParser {
 }
 
 @AsahiPrefix(["and"], "sql-where-action")
-private fun and() = prefixParser {
+private fun and() = prefixParser<WhereData> {
     val dataGetter = quest<WhereData>()
     result {
         val data = dataGetter.get()
@@ -73,7 +73,7 @@ private fun and() = prefixParser {
 }
 
 @AsahiPrefix(["or"], "sql-where-action")
-private fun or() = prefixParser {
+private fun or() = prefixParser<WhereData> {
     val dataGetter = quest<WhereData>()
     result {
         val data = dataGetter.get()
@@ -84,7 +84,7 @@ private fun or() = prefixParser {
 }
 
 @AsahiPrefix(["not"], "sql-where-action")
-private fun not() = prefixParser {
+private fun not() = prefixParser<WhereData> {
     val dataGetter = quest<WhereData>()
     result {
         val data = dataGetter.get()

--- a/src/main/kotlin/com/skillw/pouvoir/internal/core/script/common/annotation/AsahiPrefix.kt
+++ b/src/main/kotlin/com/skillw/pouvoir/internal/core/script/common/annotation/AsahiPrefix.kt
@@ -32,7 +32,7 @@ internal object AsahiPrefix : ScriptAnnotation("AsahiPrefix") {
         val names = demand.get("name", "").toArgs()
         val namespace = demand.get("namespace", "common")
 
-        com.skillw.asahi.api.prefixParser {
+        com.skillw.asahi.api.prefixParser<Any?> {
             val result = Function<Function<AsahiContext, Any?>, Quester<Any?>> {
                 result { it.apply(this) }
             }

--- a/src/main/kotlin/com/skillw/pouvoir/internal/core/script/javascript/impl/NashornLegacy.kt
+++ b/src/main/kotlin/com/skillw/pouvoir/internal/core/script/javascript/impl/NashornLegacy.kt
@@ -3,8 +3,8 @@ package com.skillw.pouvoir.internal.core.script.javascript.impl
 import com.skillw.pouvoir.Pouvoir
 import com.skillw.pouvoir.api.script.engine.hook.ScriptBridge
 import com.skillw.pouvoir.internal.core.script.javascript.PouJavaScriptEngine.SCRIPT_OBJ
-import org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory
-import org.openjdk.nashorn.api.scripting.ScriptObjectMirror
+import jdk.nashorn.api.scripting.NashornScriptEngineFactory
+import jdk.nashorn.api.scripting.ScriptObjectMirror
 import javax.script.CompiledScript
 import javax.script.Invocable
 import javax.script.ScriptEngine

--- a/src/main/kotlin/com/skillw/pouvoir/internal/core/script/javascript/impl/NashornLegacy.kt
+++ b/src/main/kotlin/com/skillw/pouvoir/internal/core/script/javascript/impl/NashornLegacy.kt
@@ -3,8 +3,8 @@ package com.skillw.pouvoir.internal.core.script.javascript.impl
 import com.skillw.pouvoir.Pouvoir
 import com.skillw.pouvoir.api.script.engine.hook.ScriptBridge
 import com.skillw.pouvoir.internal.core.script.javascript.PouJavaScriptEngine.SCRIPT_OBJ
-import jdk.nashorn.api.scripting.NashornScriptEngineFactory
-import jdk.nashorn.api.scripting.ScriptObjectMirror
+import org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory
+import org.openjdk.nashorn.api.scripting.ScriptObjectMirror
 import javax.script.CompiledScript
 import javax.script.Invocable
 import javax.script.ScriptEngine

--- a/src/main/kotlin/com/skillw/pouvoir/internal/feature/database/sql/SQLTable.kt
+++ b/src/main/kotlin/com/skillw/pouvoir/internal/feature/database/sql/SQLTable.kt
@@ -24,7 +24,7 @@ class SQLTable<T : Host<E>, E : ColumnBuilder>(private val table: Table<T, E>) :
         return table.add(name, func)
     }
 
-    override fun select(func: ActionSelect.() -> Unit): QueryTask {
+    override fun select(func: ActionSelect.() -> Unit): ResultProcessorList {
         return table.workspace(dataSource) { select(func) }
     }
 
@@ -44,7 +44,7 @@ class SQLTable<T : Host<E>, E : ColumnBuilder>(private val table: Table<T, E>) :
         return table.workspace(dataSource) { insert(*keys) { func(this) } }.run()
     }
 
-    override fun workspace(func: Query.() -> Unit): QueryTask {
+    override fun workspace(func: ExecutableSource.() -> Unit): ResultProcessorList {
         return table.workspace(dataSource, func)
     }
 

--- a/src/main/kotlin/com/skillw/pouvoir/util/FileUtil.kt
+++ b/src/main/kotlin/com/skillw/pouvoir/util/FileUtil.kt
@@ -136,7 +136,7 @@ fun File.md5(): String? {
 }
 
 fun JavaPlugin.completeYaml(file: File, ignores: Set<String> = emptySet()): Map<String, Any?> {
-    val path = file.path.substringAfter("\\").substringAfter("\\")
+    val path = file.path.substringAfter(File.separator).substringAfter(File.separator)
     return completeYaml(path, ignores)
 }
 


### PR DESCRIPTION
目前大多数taboolib的插件使用的kotlin版本都是1.5.31，taboolib库使用的也是1.5.31。
如果本插件使用过高的kotlin版本，会导致其他插件不得不对kotlin版本进行升级，无法做到更好的兼容，建议合入pr降级为1.5.31。